### PR TITLE
Added Support for AFC North Statistics being compiled

### DIFF
--- a/AFC.ipynb
+++ b/AFC.ipynb
@@ -1,16 +1,27 @@
 {
  "cells": [
   {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "",
+   "id": "63dfe36052c797d8"
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
    "id": "initial_id",
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-10-08T02:09:24.673851Z",
+     "start_time": "2024-10-08T02:09:24.250584Z"
+    }
    },
-   "outputs": [],
    "source": [
-    ""
-   ]
+    "import pandas as pd\n",
+    "import numpy as np"
+   ],
+   "outputs": [],
+   "execution_count": 1
   }
  ],
  "metadata": {

--- a/AFC.ipynb
+++ b/AFC.ipynb
@@ -3,7 +3,7 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "",
+   "source": "Import any needed libraries",
    "id": "63dfe36052c797d8"
   },
   {
@@ -12,16 +12,182 @@
    "metadata": {
     "collapsed": true,
     "ExecuteTime": {
-     "end_time": "2024-10-08T02:09:24.673851Z",
-     "start_time": "2024-10-08T02:09:24.250584Z"
+     "end_time": "2024-10-08T02:26:50.102127Z",
+     "start_time": "2024-10-08T02:26:50.018603Z"
     }
    },
    "source": [
     "import pandas as pd\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "import requests\n",
+    "import csv\n",
+    "from bs4 import BeautifulSoup"
    ],
    "outputs": [],
-   "execution_count": 1
+   "execution_count": 2
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Hard-Code List of divisions",
+   "id": "7f011ab08738e6df"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-08T02:26:51.753161Z",
+     "start_time": "2024-10-08T02:26:51.749306Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "AFC_North = ['bal', 'cin', 'cle', 'pit']",
+   "id": "8be04a843756ead1",
+   "outputs": [],
+   "execution_count": 3
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Use the requests library to send GET requests to the specified URL",
+   "id": "93ddba4b3bb25165"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "",
+   "id": "e90b581b451f5ab8"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-08T03:35:33.252840Z",
+     "start_time": "2024-10-08T03:35:32.683856Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "obj = {}\n",
+    "for team in AFC_North:\n",
+    "    url = f'https://www.espn.com/nfl/team/stats/_/name/{team}/season/2024/seasontype/2'\n",
+    "    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36'}\n",
+    "    response = requests.get(url=url, headers=headers)\n",
+    "    soup = BeautifulSoup(response.text, 'html.parser')\n",
+    "    athlete_names = soup.find_all(class_='Athlete__PlayerName')\n",
+    "    statistics = soup.find_all(class_='clr-gray-01 pr3 hs2')\n",
+    "    city = soup.find(class_='db pr3 nowrap').text\n",
+    "    team_name = soup.find(class_='db fw-bold').text\n",
+    "    team_fullname = f\"{city} {team_name}\"\n",
+    "    obj[team_fullname] = []\n",
+    "    for athlete, statistic in zip(athlete_names, statistics):\n",
+    "        athlete_name = athlete.text\n",
+    "        specific_statistic = statistic.text\n",
+    "        obj[team_fullname].append(f\"{athlete_name}: {specific_statistic}\")\n",
+    "pd.DataFrame(data=obj, index=[\"Passing Yards Leader Statistic\", \"Rushing Yards Leader Statistic\", \"Receiving Yards Leader Statistic\", \"Tackles Statistic Statistic\", \"Interceptions Leader Statistic\"])"
+   ],
+   "id": "e3c73b05b325e1a",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "                                      Baltimore Ravens  Cincinnati Bengals  \\\n",
+       "Passing Yards Leader Statistic    Lamar Jackson: 1,206   Joe Burrow: 1,370   \n",
+       "Rushing Yards Leader Statistic      Derrick Henry: 572    Chase Brown: 230   \n",
+       "Receiving Yards Leader Statistic      Zay Flowers: 269  Ja'Marr Chase: 493   \n",
+       "Tackles Statistic Statistic           Roquan Smith: 50    Logan Wilson: 52   \n",
+       "Interceptions Leader Statistic      Marlon Humphrey: 2        Vonn Bell: 1   \n",
+       "\n",
+       "                                             Cleveland Browns  \\\n",
+       "Passing Yards Leader Statistic            Deshaun Watson: 852   \n",
+       "Rushing Yards Leader Statistic               Jerome Ford: 250   \n",
+       "Receiving Yards Leader Statistic             Jerry Jeudy: 213   \n",
+       "Tackles Statistic Statistic       Jeremiah Owusu-Koramoah: 39   \n",
+       "Interceptions Leader Statistic     Jeremiah Owusu-Koramoah: 1   \n",
+       "\n",
+       "                                  Pittsburgh Steelers  \n",
+       "Passing Yards Leader Statistic     Justin Fields: 961  \n",
+       "Rushing Yards Leader Statistic      Najee Harris: 270  \n",
+       "Receiving Yards Leader Statistic  George Pickens: 310  \n",
+       "Tackles Statistic Statistic        DeShon Elliott: 39  \n",
+       "Interceptions Leader Statistic       Donte Jackson: 2  "
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Baltimore Ravens</th>\n",
+       "      <th>Cincinnati Bengals</th>\n",
+       "      <th>Cleveland Browns</th>\n",
+       "      <th>Pittsburgh Steelers</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Passing Yards Leader Statistic</th>\n",
+       "      <td>Lamar Jackson: 1,206</td>\n",
+       "      <td>Joe Burrow: 1,370</td>\n",
+       "      <td>Deshaun Watson: 852</td>\n",
+       "      <td>Justin Fields: 961</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Rushing Yards Leader Statistic</th>\n",
+       "      <td>Derrick Henry: 572</td>\n",
+       "      <td>Chase Brown: 230</td>\n",
+       "      <td>Jerome Ford: 250</td>\n",
+       "      <td>Najee Harris: 270</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Receiving Yards Leader Statistic</th>\n",
+       "      <td>Zay Flowers: 269</td>\n",
+       "      <td>Ja'Marr Chase: 493</td>\n",
+       "      <td>Jerry Jeudy: 213</td>\n",
+       "      <td>George Pickens: 310</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Tackles Statistic Statistic</th>\n",
+       "      <td>Roquan Smith: 50</td>\n",
+       "      <td>Logan Wilson: 52</td>\n",
+       "      <td>Jeremiah Owusu-Koramoah: 39</td>\n",
+       "      <td>DeShon Elliott: 39</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Interceptions Leader Statistic</th>\n",
+       "      <td>Marlon Humphrey: 2</td>\n",
+       "      <td>Vonn Bell: 1</td>\n",
+       "      <td>Jeremiah Owusu-Koramoah: 1</td>\n",
+       "      <td>Donte Jackson: 2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 33
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "",
+   "id": "d1f11f3bfbde554c"
   }
  ],
  "metadata": {


### PR DESCRIPTION
I added initial support for AFC North (Baltimore Ravens, Cincinnati Bengals, Cleveland Browns, Pittsburgh Steelers). Statistics are being compiled. For now Dataframe is printed but the intention is to save to CSV File