### PR TITLE
Added Support for AFC East being tracked and added to CSV file

### DIFF
--- a/AFC_East.ipynb
+++ b/AFC_East.ipynb
@@ -3,8 +3,8 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "Import any needed libraries",
-   "id": "63dfe36052c797d8"
+   "source": "Import any Libraries as needed",
+   "id": "faf0b42f7e7e5693"
   },
   {
    "cell_type": "code",
@@ -12,8 +12,8 @@
    "metadata": {
     "collapsed": true,
     "ExecuteTime": {
-     "end_time": "2024-10-08T18:11:05.933960Z",
-     "start_time": "2024-10-08T18:11:05.569151Z"
+     "end_time": "2024-10-08T18:20:04.609131Z",
+     "start_time": "2024-10-08T18:20:04.309360Z"
     }
    },
    "source": [
@@ -24,50 +24,44 @@
     "from bs4 import BeautifulSoup"
    ],
    "outputs": [],
+   "execution_count": 1
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Hard-Code List of divisions (AFC East)",
+   "id": "15c75c0cf072edc7"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-08T18:20:05.932399Z",
+     "start_time": "2024-10-08T18:20:05.929984Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "AFC_East = ['buf', 'mia', 'ne', 'nyj']",
+   "id": "a6df7c7cc4821a0b",
+   "outputs": [],
    "execution_count": 2
   },
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "Hard-Code List of divisions (AFC North)",
-   "id": "7f011ab08738e6df"
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-08T18:11:06.471989Z",
-     "start_time": "2024-10-08T18:11:06.469808Z"
-    }
-   },
-   "cell_type": "code",
-   "source": "AFC_North = ['bal', 'cin', 'cle', 'pit']",
-   "id": "8be04a843756ead1",
-   "outputs": [],
-   "execution_count": 3
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
    "source": "Use the requests library to send GET requests to the specified URL",
-   "id": "93ddba4b3bb25165"
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": "",
-   "id": "e90b581b451f5ab8"
+   "id": "1d6495aa852ab935"
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-08T18:23:40.735169Z",
-     "start_time": "2024-10-08T18:23:39.083194Z"
+     "end_time": "2024-10-08T18:23:43.155161Z",
+     "start_time": "2024-10-08T18:23:41.964447Z"
     }
    },
    "cell_type": "code",
    "source": [
     "obj = {}\n",
-    "for team in AFC_North:\n",
+    "for team in AFC_East:\n",
     "    url = f'https://www.espn.com/nfl/team/stats/_/name/{team}/season/2024/seasontype/2'\n",
     "    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36'}\n",
     "    response = requests.get(url=url, headers=headers)\n",
@@ -82,19 +76,20 @@
     "        athlete_name = athlete.text\n",
     "        specific_statistic = statistic.text\n",
     "        obj[team_fullname].append(f\"{specific_statistic}\")\n",
-    "AFC_North_df = pd.DataFrame(data=obj, index=[\"Passing Yards Leader Statistic\", \"Rushing Yards Leader Statistic\", \"Receiving Yards Leader Statistic\", \"Tackles Statistic Statistic\", \"Interceptions Leader Statistic\"]).T\n",
+    "AFC_East_df = pd.DataFrame(data=obj, index=[\"Passing Yards Leader Statistic\", \"Rushing Yards Leader Statistic\", \"Receiving Yards Leader Statistic\", \"Tackles Statistic Statistic\", \"Interceptions Leader Statistic\"]).T\n",
     "csv_file = 'NFL_Data.csv'\n",
-    "AFC_North_df.to_csv(csv_file, header=True, index=True, index_label=\"Team\")\n"
+    "\n",
+    "AFC_East_df.to_csv(csv_file, mode='a', index=True, header=False)\n"
    ],
-   "id": "e3c73b05b325e1a",
+   "id": "e6141a3869704465",
    "outputs": [],
-   "execution_count": 11
+   "execution_count": 10
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "",
-   "id": "d1f11f3bfbde554c"
+   "id": "8843ab6c5fd50221"
   }
  ],
  "metadata": {

--- a/NFL_Data.csv
+++ b/NFL_Data.csv
@@ -3,3 +3,7 @@ Baltimore Ravens,"1,206",572,269,50,2
 Cincinnati Bengals,"1,370",230,493,52,1
 Cleveland Browns,852,250,213,39,1
 Pittsburgh Steelers,961,270,310,39,2
+Buffalo Bills,945,309,230,54,2
+Miami Dolphins,483,183,286,39,1
+New England Patriots,696,356,180,32,1
+New York Jets,"1,093",197,292,40,2


### PR DESCRIPTION
- This PR adds support for the AFC teams being tracked in terms of statistics
- The method in which teams are added into the CSV is a bit different with AFC East, as we would merely like to append to the CSV and not create a new one altogether