### PR TITLE
Changed Column/Feature name in CSV file due to typo 

### DIFF
--- a/AFC_East.ipynb
+++ b/AFC_East.ipynb
@@ -54,8 +54,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-08T18:23:43.155161Z",
-     "start_time": "2024-10-08T18:23:41.964447Z"
+     "end_time": "2024-10-08T18:28:28.003625Z",
+     "start_time": "2024-10-08T18:28:25.164277Z"
     }
    },
    "cell_type": "code",
@@ -76,14 +76,14 @@
     "        athlete_name = athlete.text\n",
     "        specific_statistic = statistic.text\n",
     "        obj[team_fullname].append(f\"{specific_statistic}\")\n",
-    "AFC_East_df = pd.DataFrame(data=obj, index=[\"Passing Yards Leader Statistic\", \"Rushing Yards Leader Statistic\", \"Receiving Yards Leader Statistic\", \"Tackles Statistic Statistic\", \"Interceptions Leader Statistic\"]).T\n",
+    "AFC_East_df = pd.DataFrame(data=obj, index=[\"Passing Yards Leader Statistic\", \"Rushing Yards Leader Statistic\", \"Receiving Yards Leader Statistic\", \"Tackles Leader Statistic\", \"Interceptions Leader Statistic\"]).T\n",
     "csv_file = 'NFL_Data.csv'\n",
     "\n",
     "AFC_East_df.to_csv(csv_file, mode='a', index=True, header=False)\n"
    ],
    "id": "e6141a3869704465",
    "outputs": [],
-   "execution_count": 10
+   "execution_count": 11
   },
   {
    "metadata": {},

--- a/AFC_North.ipynb
+++ b/AFC_North.ipynb
@@ -60,8 +60,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-08T18:23:40.735169Z",
-     "start_time": "2024-10-08T18:23:39.083194Z"
+     "end_time": "2024-10-08T18:28:24.580248Z",
+     "start_time": "2024-10-08T18:28:21.633503Z"
     }
    },
    "cell_type": "code",
@@ -82,13 +82,13 @@
     "        athlete_name = athlete.text\n",
     "        specific_statistic = statistic.text\n",
     "        obj[team_fullname].append(f\"{specific_statistic}\")\n",
-    "AFC_North_df = pd.DataFrame(data=obj, index=[\"Passing Yards Leader Statistic\", \"Rushing Yards Leader Statistic\", \"Receiving Yards Leader Statistic\", \"Tackles Statistic Statistic\", \"Interceptions Leader Statistic\"]).T\n",
+    "AFC_North_df = pd.DataFrame(data=obj, index=[\"Passing Yards Leader Statistic\", \"Rushing Yards Leader Statistic\", \"Receiving Yards Leader Statistic\", \"Tackles Leader Statistic\", \"Interceptions Leader Statistic\"]).T\n",
     "csv_file = 'NFL_Data.csv'\n",
     "AFC_North_df.to_csv(csv_file, header=True, index=True, index_label=\"Team\")\n"
    ],
    "id": "e3c73b05b325e1a",
    "outputs": [],
-   "execution_count": 11
+   "execution_count": 12
   },
   {
    "metadata": {},

--- a/NFL_Data.csv
+++ b/NFL_Data.csv
@@ -1,4 +1,4 @@
-Team,Passing Yards Leader Statistic,Rushing Yards Leader Statistic,Receiving Yards Leader Statistic,Tackles Statistic Statistic,Interceptions Leader Statistic
+Team,Passing Yards Leader Statistic,Rushing Yards Leader Statistic,Receiving Yards Leader Statistic,Tackles Leader Statistic,Interceptions Leader Statistic
 Baltimore Ravens,"1,206",572,269,50,2
 Cincinnati Bengals,"1,370",230,493,52,1
 Cleveland Browns,852,250,213,39,1


### PR DESCRIPTION
- This PR resolves an issue with the spelling of a feature (Originally Tackles Statistic Statistic) to Tacles Leader Statistic. 
- Additionally fixes issue in the CSV